### PR TITLE
Return column names and types along with results

### DIFF
--- a/c_src/constants.cc
+++ b/c_src/constants.cc
@@ -35,25 +35,32 @@ const char kAtomExecuteStatementResult[] = "execute_statement_result";
 const char kAtomLogMessageReceived[] = "log_message_recv";
 
 //data types
-
-const char kAtomText[] = "text";
-const char kAtomTinyInt[] = "tinyint";
-const char kAtomSmallInt[] = "smallint";
-const char kAtomInt[] = "int";
-const char kAtomDate[] = "date";
+const char kAtomAscii[] = "ascii";
 const char kAtomBigInt[] = "bigint";
 const char kAtomBlob[] = "blob";
-const char kAtomBool[] = "bool";
-const char kAtomFloat[] = "float";
-const char kAtomDouble[] = "double";
-const char kAtomInet[] = "inet";
-const char kAtomUuid[] = "uuid";
+const char kAtomBool[] = "boolean";
+const char kAtomCounter[] = "counter";
+const char kAtomDate[] = "date";
 const char kAtomDecimal[] = "decimal";
+const char kAtomDouble[] = "double";
+const char kAtomFloat[] = "float";
+const char kAtomFrozen[] = "frozen";
+const char kAtomInet[] = "inet";
+const char kAtomInt[] = "int";
 const char kAtomList[] = "list";
-const char kAtomSet[] = "set";
 const char kAtomMap[] = "map";
-const char kAtomTuple[] = "tuple";
+const char kAtomSet[] = "set";
+const char kAtomSmallInt[] = "smallint";
+const char kAtomText[] = "text";
+const char kAtomTime[] = "time";
 const char kAtomTimestamp[] = "timestamp";
+const char kAtomTimeUuid[] = "timeuuid";
+const char kAtomTinyInt[] = "tinyint";
+const char kAtomTuple[] = "tuple";
+const char kAtomUuid[] = "uuid";
+const char kAtomVarchar[] = "varchar";
+const char kAtomVarint[] = "varint";
+
 //cluster settings atoms
 
 const char kAtomClusterDefaultConsistencyLevel[] = "default_consistency_level";

--- a/c_src/constants.cc
+++ b/c_src/constants.cc
@@ -21,7 +21,7 @@ const char kAtomTrue[] = "true";
 const char kAtomFalse[] = "false";
 const char kAtomNull[] = "null";
 const char kAtomBadArg[] = "badarg";
-const char kAtomOptions[] = "options";    
+const char kAtomOptions[] = "options";
 const char kAtomConsistencyLevel[] = "consistency_level";
 const char kAtomSerialConsistencyLevel[] = "serial_consistency_level";
 const char kAtomLogMsgRecord[] = "log_msg";
@@ -34,6 +34,26 @@ const char kAtomPreparedStatementResult[] = "prepared_statement_result";
 const char kAtomExecuteStatementResult[] = "execute_statement_result";
 const char kAtomLogMessageReceived[] = "log_message_recv";
 
+//data types
+
+const char kAtomText[] = "text";
+const char kAtomTinyInt[] = "tinyint";
+const char kAtomSmallInt[] = "smallint";
+const char kAtomInt[] = "int";
+const char kAtomDate[] = "date";
+const char kAtomBigInt[] = "bigint";
+const char kAtomBlob[] = "blob";
+const char kAtomBool[] = "bool";
+const char kAtomFloat[] = "float";
+const char kAtomDouble[] = "double";
+const char kAtomInet[] = "inet";
+const char kAtomUuid[] = "uuid";
+const char kAtomDecimal[] = "decimal";
+const char kAtomList[] = "list";
+const char kAtomSet[] = "set";
+const char kAtomMap[] = "map";
+const char kAtomTuple[] = "tuple";
+const char kAtomTimestamp[] = "timestamp";
 //cluster settings atoms
 
 const char kAtomClusterDefaultConsistencyLevel[] = "default_consistency_level";

--- a/c_src/constants.cc
+++ b/c_src/constants.cc
@@ -58,6 +58,7 @@ const char kAtomTimeUuid[] = "timeuuid";
 const char kAtomTinyInt[] = "tinyint";
 const char kAtomTuple[] = "tuple";
 const char kAtomUuid[] = "uuid";
+const char kAtomUdt[] = "udt";
 const char kAtomVarchar[] = "varchar";
 const char kAtomVarint[] = "varint";
 

--- a/c_src/constants.h
+++ b/c_src/constants.h
@@ -36,25 +36,31 @@ extern const char kAtomExecuteStatementResult[];
 extern const char kAtomLogMessageReceived[];
 
 //data types
-
-extern const char kAtomText[];
-extern const char kAtomTinyInt[];
-extern const char kAtomSmallInt[];
-extern const char kAtomInt[];
-extern const char kAtomDate[];
+extern const char kAtomAscii[];
 extern const char kAtomBigInt[];
 extern const char kAtomBlob[];
 extern const char kAtomBool[];
-extern const char kAtomFloat[];
-extern const char kAtomDouble[];
-extern const char kAtomInet[];
-extern const char kAtomUuid[];
+extern const char kAtomCounter[];
+extern const char kAtomDate[];
 extern const char kAtomDecimal[];
+extern const char kAtomDouble[];
+extern const char kAtomFloat[];
+extern const char kAtomFrozen[];
+extern const char kAtomInet[];
+extern const char kAtomInt[];
 extern const char kAtomList[];
-extern const char kAtomSet[];
 extern const char kAtomMap[];
-extern const char kAtomTuple[];
+extern const char kAtomSet[];
+extern const char kAtomSmallInt[];
+extern const char kAtomText[];
+extern const char kAtomTime[];
 extern const char kAtomTimestamp[];
+extern const char kAtomTimeUuid[];
+extern const char kAtomTinyInt[];
+extern const char kAtomTuple[];
+extern const char kAtomUuid[];
+extern const char kAtomVarchar[];
+extern const char kAtomVarint[];
 
 //cluster settings atoms
 

--- a/c_src/constants.h
+++ b/c_src/constants.h
@@ -35,6 +35,27 @@ extern const char kAtomPreparedStatementResult[];
 extern const char kAtomExecuteStatementResult[];
 extern const char kAtomLogMessageReceived[];
 
+//data types
+
+extern const char kAtomText[];
+extern const char kAtomTinyInt[];
+extern const char kAtomSmallInt[];
+extern const char kAtomInt[];
+extern const char kAtomDate[];
+extern const char kAtomBigInt[];
+extern const char kAtomBlob[];
+extern const char kAtomBool[];
+extern const char kAtomFloat[];
+extern const char kAtomDouble[];
+extern const char kAtomInet[];
+extern const char kAtomUuid[];
+extern const char kAtomDecimal[];
+extern const char kAtomList[];
+extern const char kAtomSet[];
+extern const char kAtomMap[];
+extern const char kAtomTuple[];
+extern const char kAtomTimestamp[];
+
 //cluster settings atoms
 
 extern const char kAtomClusterDefaultConsistencyLevel[];

--- a/c_src/constants.h
+++ b/c_src/constants.h
@@ -59,6 +59,7 @@ extern const char kAtomTimeUuid[];
 extern const char kAtomTinyInt[];
 extern const char kAtomTuple[];
 extern const char kAtomUuid[];
+extern const char kAtomUdt[];
 extern const char kAtomVarchar[];
 extern const char kAtomVarint[];
 

--- a/c_src/data_conversion.cc
+++ b/c_src/data_conversion.cc
@@ -106,22 +106,28 @@ ERL_NIF_TERM cass_data_type_to_nif_term(ErlNifEnv* env, const CassDataType *data
 
     switch(typeValue){
         case CASS_VALUE_TYPE_TEXT:
-        case CASS_VALUE_TYPE_ASCII:
-        case CASS_VALUE_TYPE_VARCHAR:
             return ATOMS.atomText;
 
+        case CASS_VALUE_TYPE_ASCII:
+            return ATOMS.atomAscii;
+
+        case CASS_VALUE_TYPE_VARCHAR:
+            return ATOMS.atomText;
 
         case CASS_VALUE_TYPE_TIMESTAMP:
             return ATOMS.atomTimestamp;
 
         case CASS_VALUE_TYPE_TIME:
-            return ATOMS.atomBigInt;
+            return ATOMS.atomTime;
 
         case CASS_VALUE_TYPE_TINY_INT:
             return ATOMS.atomTinyInt;
 
         case CASS_VALUE_TYPE_SMALL_INT:
             return ATOMS.atomSmallInt;
+
+        case CASS_VALUE_TYPE_VARINT:
+            return ATOMS.atomVarint;
 
         case CASS_VALUE_TYPE_INT:
             return ATOMS.atomInt;
@@ -148,6 +154,8 @@ ERL_NIF_TERM cass_data_type_to_nif_term(ErlNifEnv* env, const CassDataType *data
             return ATOMS.atomInet;
 
         case CASS_VALUE_TYPE_TIMEUUID:
+            return ATOMS.atomTimeUuid;
+
         case CASS_VALUE_TYPE_UUID:
             return ATOMS.atomUuid;
 

--- a/c_src/data_conversion.cc
+++ b/c_src/data_conversion.cc
@@ -400,7 +400,7 @@ ERL_NIF_TERM cass_result_to_erlang_term(ErlNifEnv* env, const CassResult* result
 
     if(rowsCount == 0) {
         ERL_NIF_TERM rows = enif_make_list(env, 0);
-        return enif_make_tuple2(env, rows, columnData);
+        return enif_make_tuple3(env, ATOMS.atomOk, columnData, rows);
     }
 
     ERL_NIF_TERM nifArrayColumns[columnsCount];
@@ -421,5 +421,5 @@ ERL_NIF_TERM cass_result_to_erlang_term(ErlNifEnv* env, const CassResult* result
 
 
     ERL_NIF_TERM rows = enif_make_list_from_array(env, nifArrayRows, static_cast<unsigned>(rowsCount));
-    return enif_make_tuple2(env, rows, columnData);
+    return enif_make_tuple3(env, ATOMS.atomOk, columnData, rows);
 }

--- a/c_src/data_conversion.cc
+++ b/c_src/data_conversion.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string.h>
+#include <vector>
 
 ERL_NIF_TERM string_to_erlang_term(ErlNifEnv* env, const CassValue* value);
 ERL_NIF_TERM blob_to_erlang_term(ErlNifEnv* env, const CassValue* value);
@@ -90,6 +91,101 @@ ERL_NIF_TERM cass_value_to_nif_term(ErlNifEnv* env, const CassValue* value)
 
         default:
             //unsuported types and null values
+            return ATOMS.atomNull;
+    }
+}
+
+ERL_NIF_TERM cass_data_type_to_nif_term(ErlNifEnv* env, const CassDataType *dataType)
+{
+    const CassDataType* valueDataType;
+    const CassDataType* keyDataType;
+    size_t subTypesLength;
+    std::vector<ERL_NIF_TERM> tupleColumnData;
+
+    CassValueType typeValue = cass_data_type_type(dataType);
+
+    switch(typeValue){
+        case CASS_VALUE_TYPE_TEXT:
+        case CASS_VALUE_TYPE_ASCII:
+        case CASS_VALUE_TYPE_VARCHAR:
+            return ATOMS.atomText;
+
+
+        case CASS_VALUE_TYPE_TIMESTAMP:
+            return ATOMS.atomTimestamp;
+
+        case CASS_VALUE_TYPE_TIME:
+            return ATOMS.atomBigInt;
+
+        case CASS_VALUE_TYPE_TINY_INT:
+            return ATOMS.atomTinyInt;
+
+        case CASS_VALUE_TYPE_SMALL_INT:
+            return ATOMS.atomSmallInt;
+
+        case CASS_VALUE_TYPE_INT:
+            return ATOMS.atomInt;
+
+        case CASS_VALUE_TYPE_BIGINT:
+            return ATOMS.atomBigInt;
+
+        case CASS_VALUE_TYPE_DATE:
+            return ATOMS.atomDate;
+
+        case CASS_VALUE_TYPE_BLOB:
+            return ATOMS.atomBlob;
+
+        case CASS_VALUE_TYPE_BOOLEAN:
+            return ATOMS.atomBool;
+
+        case CASS_VALUE_TYPE_FLOAT:
+            return ATOMS.atomFloat;
+
+        case CASS_VALUE_TYPE_DOUBLE:
+            return ATOMS.atomDouble;
+
+        case CASS_VALUE_TYPE_INET:
+            return ATOMS.atomInet;
+
+        case CASS_VALUE_TYPE_TIMEUUID:
+        case CASS_VALUE_TYPE_UUID:
+            return ATOMS.atomUuid;
+
+        case CASS_VALUE_TYPE_DECIMAL:
+            return ATOMS.atomDecimal;
+
+        case CASS_VALUE_TYPE_LIST:
+            valueDataType = cass_data_type_sub_data_type(dataType, 0);
+            return enif_make_tuple2(env,
+                                    ATOMS.atomList,
+                                    cass_data_type_to_nif_term(env, valueDataType));
+
+        case CASS_VALUE_TYPE_MAP:
+            keyDataType = cass_data_type_sub_data_type(dataType, 0);
+            valueDataType = cass_data_type_sub_data_type(dataType, 1);
+            return enif_make_tuple3(env,
+                                    ATOMS.atomMap,
+                                    cass_data_type_to_nif_term(env, keyDataType),
+                                    cass_data_type_to_nif_term(env, valueDataType));
+
+
+        case CASS_VALUE_TYPE_SET:
+            valueDataType = cass_data_type_sub_data_type(dataType, 0);
+            return enif_make_tuple2(env,
+                                    ATOMS.atomSet,
+                                    cass_data_type_to_nif_term(env, valueDataType));
+
+        case CASS_VALUE_TYPE_TUPLE:
+            subTypesLength = cass_data_type_sub_type_count(dataType);
+            for(size_t i = 0; i < subTypesLength; i++){
+                valueDataType = cass_data_type_sub_data_type(dataType, i);
+                tupleColumnData.push_back(cass_data_type_to_nif_term(env, valueDataType));
+            }
+            return enif_make_tuple2(env,
+                                    ATOMS.atomTuple,
+                                    enif_make_list_from_array(env, tupleColumnData.data(), tupleColumnData.size()));
+
+        default:
             return ATOMS.atomNull;
     }
 }
@@ -276,15 +372,36 @@ ERL_NIF_TERM udt_to_erlang_term(ErlNifEnv* env, const CassValue* value)
 }
 
 //convert CassResult into erlang term
+ERL_NIF_TERM column_data_to_erlang_term(ErlNifEnv* env, const CassResult* result, size_t columnsCount)
+{
+    ERL_NIF_TERM nifArrayColumnNames[columnsCount];
+
+    for(size_t index = 0; index < columnsCount; index++){
+        const char* name;
+        size_t name_length;
+
+        CassError code = cass_result_column_name(result, index, &name, &name_length);
+        if (code != CASS_OK)
+            return enif_make_list(env, 0);
+
+        const CassDataType *columnDataType = cass_result_column_data_type (result, index);
+        ERL_NIF_TERM datatypeName = cass_data_type_to_nif_term(env, columnDataType);
+
+        nifArrayColumnNames[index] = enif_make_tuple2(env, make_binary(env, name, name_length), datatypeName);
+    }
+    return enif_make_list_from_array(env, nifArrayColumnNames, static_cast<unsigned>(columnsCount));
+}
 
 ERL_NIF_TERM cass_result_to_erlang_term(ErlNifEnv* env, const CassResult* result)
 {
     size_t rowsCount = cass_result_row_count(result);
-
-    if(rowsCount == 0)
-        return enif_make_list(env, 0);
-
     size_t columnsCount = cass_result_column_count(result);
+    ERL_NIF_TERM columnData = column_data_to_erlang_term(env, result, columnsCount);
+
+    if(rowsCount == 0) {
+        ERL_NIF_TERM rows = enif_make_list(env, 0);
+        return enif_make_tuple2(env, rows, columnData);
+    }
 
     ERL_NIF_TERM nifArrayColumns[columnsCount];
     ERL_NIF_TERM nifArrayRows[rowsCount];
@@ -296,12 +413,13 @@ ERL_NIF_TERM cass_result_to_erlang_term(ErlNifEnv* env, const CassResult* result
     while (cass_iterator_next(iterator.get()))
     {
         const CassRow* row = cass_iterator_get_row(iterator.get());
-
         for(size_t i = 0; i < columnsCount; i++)
             nifArrayColumns[i] = cass_value_to_nif_term(env, cass_row_get_column(row, i));
 
         nifArrayRows[rowIndex++] = enif_make_tuple_from_array(env, nifArrayColumns, static_cast<unsigned>(columnsCount));
     }
 
-    return enif_make_list_from_array(env, nifArrayRows, static_cast<unsigned>(rowsCount));
+
+    ERL_NIF_TERM rows = enif_make_list_from_array(env, nifArrayRows, static_cast<unsigned>(rowsCount));
+    return enif_make_tuple2(env, rows, columnData);
 }

--- a/c_src/erlcass.cc
+++ b/c_src/erlcass.cc
@@ -64,6 +64,7 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     ATOMS.atomTinyInt = make_atom(env, erlcass::kAtomTinyInt);
     ATOMS.atomTuple = make_atom(env, erlcass::kAtomTuple);
     ATOMS.atomUuid = make_atom(env, erlcass::kAtomUuid);
+    ATOMS.atomUdt = make_atom(env, erlcass::kAtomUdt);
     ATOMS.atomVarchar = make_atom(env, erlcass::kAtomVarchar);
     ATOMS.atomVarint = make_atom(env, erlcass::kAtomVarint);
 

--- a/c_src/erlcass.cc
+++ b/c_src/erlcass.cc
@@ -41,24 +41,31 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 
     //data types
 
-    ATOMS.atomText = make_atom(env, erlcass::kAtomText);
-    ATOMS.atomTinyInt = make_atom(env, erlcass::kAtomTinyInt);
-    ATOMS.atomSmallInt = make_atom(env, erlcass::kAtomSmallInt);
-    ATOMS.atomInt = make_atom(env, erlcass::kAtomInt);
-    ATOMS.atomDate = make_atom(env, erlcass::kAtomDate);
+    ATOMS.atomAscii = make_atom(env, erlcass::kAtomAscii);
     ATOMS.atomBigInt = make_atom(env, erlcass::kAtomBigInt);
     ATOMS.atomBlob = make_atom(env, erlcass::kAtomBlob);
     ATOMS.atomBool = make_atom(env, erlcass::kAtomBool);
-    ATOMS.atomFloat = make_atom(env, erlcass::kAtomFloat);
-    ATOMS.atomDouble = make_atom(env, erlcass::kAtomDouble);
-    ATOMS.atomInet = make_atom(env, erlcass::kAtomInet);
-    ATOMS.atomUuid = make_atom(env, erlcass::kAtomUuid);
+    ATOMS.atomCounter = make_atom(env, erlcass::kAtomCounter);
+    ATOMS.atomDate = make_atom(env, erlcass::kAtomDate);
     ATOMS.atomDecimal = make_atom(env, erlcass::kAtomDecimal);
+    ATOMS.atomDouble = make_atom(env, erlcass::kAtomDouble);
+    ATOMS.atomFloat = make_atom(env, erlcass::kAtomFloat);
+    ATOMS.atomFrozen =make_atom(env, erlcass::kAtomFrozen);
+    ATOMS.atomInet = make_atom(env, erlcass::kAtomInet);
+    ATOMS.atomInt = make_atom(env, erlcass::kAtomInt);
     ATOMS.atomList = make_atom(env, erlcass::kAtomList);
-    ATOMS.atomSet = make_atom(env, erlcass::kAtomSet);
     ATOMS.atomMap = make_atom(env, erlcass::kAtomMap);
-    ATOMS.atomTuple = make_atom(env, erlcass::kAtomTuple);
+    ATOMS.atomSet = make_atom(env, erlcass::kAtomSet);
+    ATOMS.atomSmallInt = make_atom(env, erlcass::kAtomSmallInt);
+    ATOMS.atomText = make_atom(env, erlcass::kAtomText);
+    ATOMS.atomTime = make_atom(env, erlcass::kAtomTime);
     ATOMS.atomTimestamp = make_atom(env, erlcass::kAtomTimestamp);
+    ATOMS.atomTimeUuid = make_atom(env, erlcass::kAtomTimeUuid);
+    ATOMS.atomTinyInt = make_atom(env, erlcass::kAtomTinyInt);
+    ATOMS.atomTuple = make_atom(env, erlcass::kAtomTuple);
+    ATOMS.atomUuid = make_atom(env, erlcass::kAtomUuid);
+    ATOMS.atomVarchar = make_atom(env, erlcass::kAtomVarchar);
+    ATOMS.atomVarint = make_atom(env, erlcass::kAtomVarint);
 
     //cluster settings atoms
 

--- a/c_src/erlcass.cc
+++ b/c_src/erlcass.cc
@@ -39,6 +39,27 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     ATOMS.atomExecuteStatementResult = make_atom(env, erlcass::kAtomExecuteStatementResult);
     ATOMS.atomLogMessageReceived = make_atom(env, erlcass::kAtomLogMessageReceived);
 
+    //data types
+
+    ATOMS.atomText = make_atom(env, erlcass::kAtomText);
+    ATOMS.atomTinyInt = make_atom(env, erlcass::kAtomTinyInt);
+    ATOMS.atomSmallInt = make_atom(env, erlcass::kAtomSmallInt);
+    ATOMS.atomInt = make_atom(env, erlcass::kAtomInt);
+    ATOMS.atomDate = make_atom(env, erlcass::kAtomDate);
+    ATOMS.atomBigInt = make_atom(env, erlcass::kAtomBigInt);
+    ATOMS.atomBlob = make_atom(env, erlcass::kAtomBlob);
+    ATOMS.atomBool = make_atom(env, erlcass::kAtomBool);
+    ATOMS.atomFloat = make_atom(env, erlcass::kAtomFloat);
+    ATOMS.atomDouble = make_atom(env, erlcass::kAtomDouble);
+    ATOMS.atomInet = make_atom(env, erlcass::kAtomInet);
+    ATOMS.atomUuid = make_atom(env, erlcass::kAtomUuid);
+    ATOMS.atomDecimal = make_atom(env, erlcass::kAtomDecimal);
+    ATOMS.atomList = make_atom(env, erlcass::kAtomList);
+    ATOMS.atomSet = make_atom(env, erlcass::kAtomSet);
+    ATOMS.atomMap = make_atom(env, erlcass::kAtomMap);
+    ATOMS.atomTuple = make_atom(env, erlcass::kAtomTuple);
+    ATOMS.atomTimestamp = make_atom(env, erlcass::kAtomTimestamp);
+
     //cluster settings atoms
 
     ATOMS.atomClusterDefaultConsistencyLevel = make_atom(env, erlcass::kAtomClusterDefaultConsistencyLevel);

--- a/c_src/erlcass.h
+++ b/c_src/erlcass.h
@@ -25,6 +25,27 @@ struct atoms
     ERL_NIF_TERM atomExecuteStatementResult;
     ERL_NIF_TERM atomLogMessageReceived;
 
+    //data types
+
+    ERL_NIF_TERM atomList;
+    ERL_NIF_TERM atomSet;
+    ERL_NIF_TERM atomMap;
+    ERL_NIF_TERM atomTuple;
+    ERL_NIF_TERM atomText;
+    ERL_NIF_TERM atomTinyInt;
+    ERL_NIF_TERM atomSmallInt;
+    ERL_NIF_TERM atomInt;
+    ERL_NIF_TERM atomDate;
+    ERL_NIF_TERM atomBigInt;
+    ERL_NIF_TERM atomBlob;
+    ERL_NIF_TERM atomBool;
+    ERL_NIF_TERM atomFloat;
+    ERL_NIF_TERM atomDouble;
+    ERL_NIF_TERM atomInet;
+    ERL_NIF_TERM atomUuid;
+    ERL_NIF_TERM atomDecimal;
+    ERL_NIF_TERM atomTimestamp;
+
     //cluster setings atoms
 
     ERL_NIF_TERM atomClusterDefaultConsistencyLevel;
@@ -36,7 +57,7 @@ struct atoms
     ERL_NIF_TERM atomClusterSettingQueueSizeEvent;
     ERL_NIF_TERM atomClusterSettingCoreConnectionsPerHost;
     ERL_NIF_TERM atomClusterSettingMaxConnectionsPerHost;
-    ERL_NIF_TERM atomClusterSettingReconnectWaitTime;    
+    ERL_NIF_TERM atomClusterSettingReconnectWaitTime;
     ERL_NIF_TERM atomClusterSettingMaxConcurrentCreation;
     ERL_NIF_TERM atomClusterSettingMaxConcurrentRequestsThreshold;
     ERL_NIF_TERM atomClusterSettingMaxRequestsPerFlush;

--- a/c_src/erlcass.h
+++ b/c_src/erlcass.h
@@ -50,6 +50,7 @@ struct atoms
     ERL_NIF_TERM atomTinyInt;
     ERL_NIF_TERM atomTuple;
     ERL_NIF_TERM atomUuid;
+    ERL_NIF_TERM atomUdt;
     ERL_NIF_TERM atomVarchar;
     ERL_NIF_TERM atomVarint;
 

--- a/c_src/erlcass.h
+++ b/c_src/erlcass.h
@@ -27,24 +27,31 @@ struct atoms
 
     //data types
 
-    ERL_NIF_TERM atomList;
-    ERL_NIF_TERM atomSet;
-    ERL_NIF_TERM atomMap;
-    ERL_NIF_TERM atomTuple;
-    ERL_NIF_TERM atomText;
-    ERL_NIF_TERM atomTinyInt;
-    ERL_NIF_TERM atomSmallInt;
-    ERL_NIF_TERM atomInt;
-    ERL_NIF_TERM atomDate;
+    ERL_NIF_TERM atomAscii;
     ERL_NIF_TERM atomBigInt;
     ERL_NIF_TERM atomBlob;
     ERL_NIF_TERM atomBool;
-    ERL_NIF_TERM atomFloat;
-    ERL_NIF_TERM atomDouble;
-    ERL_NIF_TERM atomInet;
-    ERL_NIF_TERM atomUuid;
+    ERL_NIF_TERM atomCounter;
+    ERL_NIF_TERM atomDate;
     ERL_NIF_TERM atomDecimal;
+    ERL_NIF_TERM atomDouble;
+    ERL_NIF_TERM atomFloat;
+    ERL_NIF_TERM atomFrozen;
+    ERL_NIF_TERM atomInet;
+    ERL_NIF_TERM atomInt;
+    ERL_NIF_TERM atomList;
+    ERL_NIF_TERM atomMap;
+    ERL_NIF_TERM atomSet;
+    ERL_NIF_TERM atomSmallInt;
+    ERL_NIF_TERM atomText;
+    ERL_NIF_TERM atomTime;
     ERL_NIF_TERM atomTimestamp;
+    ERL_NIF_TERM atomTimeUuid;
+    ERL_NIF_TERM atomTinyInt;
+    ERL_NIF_TERM atomTuple;
+    ERL_NIF_TERM atomUuid;
+    ERL_NIF_TERM atomVarchar;
+    ERL_NIF_TERM atomVarint;
 
     //cluster setings atoms
 

--- a/c_src/nif_cass_session.cc
+++ b/c_src/nif_cass_session.cc
@@ -145,7 +145,7 @@ void on_statement_executed(CassFuture* future, void* user_data)
         else
         {
             const CassResult* cassResult = cass_future_get_result(future);
-            result = enif_make_tuple2(cb->env, ATOMS.atomOk, cass_result_to_erlang_term(cb->env, cassResult));
+            result = cass_result_to_erlang_term(cb->env, cassResult);
             cass_result_free(cassResult);
         }
 

--- a/test/integrity_test_SUITE.erl
+++ b/test/integrity_test_SUITE.erl
@@ -47,26 +47,28 @@ end_per_suite(_Config) ->
 
 create_keyspace(_Config) ->
     erlcass:query(<<"DROP KEYSPACE erlang_driver_test">>),
-    {ok, []} = erlcass:query(<<"CREATE KEYSPACE erlang_driver_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}">>).
+    {ok, [], []} = erlcass:query(<<"CREATE KEYSPACE erlang_driver_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}">>).
 
 create_table(_Config) ->
-    {ok, []} = erlcass:query(<<"CREATE TABLE erlang_driver_test.entries1 (id varchar, age int, email varchar, PRIMARY KEY(id))">>).
+    {ok, [], []} = erlcass:query(<<"CREATE TABLE erlang_driver_test.entries1 (id varchar, age int, email varchar, PRIMARY KEY(id))">>).
 
 simple_insertion_roundtrip(_Config) ->
     Id = <<"hello">>,
     Age = 18,
     Email = <<"test@test.com">>,
 
-    {ok, []} = erlcass:query(<<"INSERT INTO erlang_driver_test.entries1(id, age, email) VALUES ('",
+    {ok, [], []} = erlcass:query(<<"INSERT INTO erlang_driver_test.entries1(id, age, email) VALUES ('",
         Id/binary,"',",
         (integer_to_binary(18))/binary, ", '",
         Email/binary, "')">>),
 
-    {ok, [{Id, Age, Email}]} = erlcass:query(<<"SELECT id, age, email FROM erlang_driver_test.entries1">>).
+    Cols = [{<<"id">>, text},{<<"age">>, int}, {<<"email">>, text}],
+    {ok, Cols, [{Id, Age, Email}]} = erlcass:query(<<"SELECT id, age, email FROM erlang_driver_test.entries1">>).
+
 
 emptiness(_Config) ->
-    {ok, []} = erlcass:query(<<"update erlang_driver_test.entries1 set email = null where id = 'hello';">>),
-    {ok, [{null}]} = erlcass:query(<<"select email from erlang_driver_test.entries1 where id = 'hello';">>).
+    {ok, [], []} = erlcass:query(<<"update erlang_driver_test.entries1 set email = null where id = 'hello';">>),
+    {ok, [{<<"email">>, text}], [{null}]} = erlcass:query(<<"select email from erlang_driver_test.entries1 where id = 'hello';">>).
 
 async_insertion_roundtrip(_Config) ->
     Id = <<"hello_async">>,
@@ -80,7 +82,7 @@ async_insertion_roundtrip(_Config) ->
 
     receive
         {execute_statement_result, Tag, Result} ->
-            Result = {ok, []}
+            Result = {ok, [], []}
 
         after 10000 ->
             ct:fail("Timeout on executing query ~n", [])
@@ -90,7 +92,8 @@ async_insertion_roundtrip(_Config) ->
 
     receive
         {execute_statement_result, Tag2, Result2} ->
-            {ok, List} = Result2,
+            Cols = [{<<"id">>, text},{<<"age">>, int}, {<<"email">>, text}],
+            {ok, Cols, List} = Result2,
             {Id, Age, Email} = lists:last(List)
 
         after 10000 ->
@@ -111,8 +114,12 @@ datatypes_columns(I, [ColumnType|Rest], Bin) ->
 
 all_datatypes(_Config) ->
     Cols = datatypes_columns([ascii, bigint, blob, boolean, decimal, double, float, int, timestamp, uuid, varchar, varint, timeuuid, inet, tinyint, smallint, date, time]),
+    SelectCols = [{<<"col1">>, ascii}, {<<"col2">>, bigint},    {<<"col3">>,  blob}, {<<"col4">>,  boolean}, {<<"col5">>,  decimal}, {<<"col6">>, double}, {<<"col7">>, float},
+                  {<<"col8">>, int},  {<<"col9">>, timestamp}, {<<"col10">>, uuid}, {<<"col11">>, text}, {<<"col12">>, varint},    {<<"col13">>, timeuuid},  {<<"col14">>, inet},
+                  {<<"col15">>,tinyint}, {<<"col16">>, smallint}, {<<"col17">>,date}, {<<"col18">>, time}],
+
     CreationQ = <<"CREATE TABLE erlang_driver_test.entries2(",  Cols/binary, " PRIMARY KEY(col1));">>,
-    {ok, []} = erlcass:query(CreationQ),
+    {ok, [], []} = erlcass:query(CreationQ),
 
     AsciiValBin = <<"hello">>,
     BigIntPositive = 9223372036854775807,
@@ -139,7 +146,7 @@ all_datatypes(_Config) ->
     ok = erlcass:add_prepare_statement(insert_all_datatypes, InsertQuery),
     ok = erlcass:add_prepare_statement(select_all_datatypes, SelectQuery),
 
-    {ok, []} = erlcass:execute(insert_all_datatypes, [
+    {ok, [], []} = erlcass:execute(insert_all_datatypes, [
         AsciiValBin,
         BigIntPositive,
         Blob,
@@ -160,7 +167,7 @@ all_datatypes(_Config) ->
         Time
     ]),
 
-    {ok, [Result]} = erlcass:execute(select_all_datatypes, [AsciiValBin]),
+    {ok, SelectCols, [Result]} = erlcass:execute(select_all_datatypes, [AsciiValBin]),
 
     {AsciiValBin, BigIntPositive, Blob, BooleanTrue, DecimalPositive, DoublePositive, _, IntPositive, Timestamp, Uuid, Varchar1, Varint1, Timeuuid, Inet, TinyIntPositive, SmallIntPositive, Date, Time} = Result,
 
@@ -176,7 +183,7 @@ all_datatypes(_Config) ->
     Varchar2 = <<"åäö"/utf8>>,
     Varint2 = erlang:integer_to_binary(123124211928301970128391280192830198049113123),
 
-    {ok, []} = erlcass:execute(insert_all_datatypes, ?BIND_BY_NAME, [
+    {ok, [], []} = erlcass:execute(insert_all_datatypes, ?BIND_BY_NAME, [
         {<<"col1">>, AsciiString},
         {<<"col2">>, BigIntNegative},
         {<<"col3">>, Blob},
@@ -197,15 +204,15 @@ all_datatypes(_Config) ->
         {<<"col18">>, Time}
     ]),
 
-    {ok, [Result2]} = erlcass:execute(select_all_datatypes, ?BIND_BY_NAME, [{<<"col1">>, AsciiString}]),
+    {ok, _, [Result2]} = erlcass:execute(select_all_datatypes, ?BIND_BY_NAME, [{<<"col1">>, AsciiString}]),
 
     BinAsciiString = list_to_binary(AsciiString),
     {BinAsciiString, BigIntNegative, Blob, BooleanFalse, DecimalNegative, DoubleNegative, _, IntNegative, Timestamp, Uuid, Varchar2, Varint2, Timeuuid, Inet, TinyIntNegative, SmallIntNegative, Date, Time} = Result2,
     ok.
 
 async_custom_tag(_Config) ->
-    CreationQ = <<"CREATE TABLE erlang_driver_test.async_custom_tag(key int PRIMARY KEY, value map<text,text>)">>,
-    {ok, []} = erlcass:query(CreationQ),
+    CreationQ = <<"CREATE TABLE erlang_driver_test.async_custom_tag(key int PRIMARY KEY, value map<text, text>)">>,
+    {ok, [], []} = erlcass:query(CreationQ),
 
     QuerySelect  = <<"SELECT value FROM erlang_driver_test.async_custom_tag where key = ?">>,
     Tag1 = {mytag, 1},
@@ -216,7 +223,8 @@ async_custom_tag(_Config) ->
 
     receive
         {execute_statement_result, Tag1, Rs} ->
-            {ok, []} = Rs,
+            Cols = [{<<"value">>, {map, text, text}}],
+            {ok, Cols, []} = Rs,
             ok
     after 10000 ->
         ct:fail("Timeout on executing query ~n", [])
@@ -225,7 +233,7 @@ async_custom_tag(_Config) ->
 
 prepared_bind_by_name_index(_Config) ->
     CreationQ = <<"CREATE TABLE erlang_driver_test.test_map(key int PRIMARY KEY, value map<text,text>)">>,
-    {ok, []} = erlcass:query(CreationQ),
+    {ok, [], []} = erlcass:query(CreationQ),
 
     CollectionIndex1 = <<"my_index">>,
     CollectionValue1 = <<"my_value">>,
@@ -245,15 +253,15 @@ prepared_bind_by_name_index(_Config) ->
     ok = erlcass:add_prepare_statement(insert_test_bind_serial_q, QueryInsertSerialConsistency),
     ok = erlcass:add_prepare_statement(select_test_bind, QuerySelect),
 
-    {ok, []} = erlcass:execute(insert_test_bind, ?BIND_BY_NAME, [
+    {ok, [], []} = erlcass:execute(insert_test_bind, ?BIND_BY_NAME, [
         {<<"key(value)">>, CollectionIndex1},
         {<<"value(value)">>, CollectionValue1},
         {<<"key">>, Key1}
     ]),
 
-    {ok, []} = erlcass:execute(insert_test_bind, [CollectionIndex2, CollectionValue2, Key2]),
-    {ok, [{[{CollectionIndex1, CollectionValue1}]}]} = erlcass:execute(select_test_bind, ?BIND_BY_NAME, [{<<"key">>, Key1}]),
-    {ok, [{[{CollectionIndex2, CollectionValue2}]}]} = erlcass:execute(select_test_bind, [Key2]),
+    {ok, [], []} = erlcass:execute(insert_test_bind, [CollectionIndex2, CollectionValue2, Key2]),
+    {ok, _, [{[{CollectionIndex1, CollectionValue1}]}]} = erlcass:execute(select_test_bind, ?BIND_BY_NAME, [{<<"key">>, Key1}]),
+    {ok, _, [{[{CollectionIndex2, CollectionValue2}]}]} = erlcass:execute(select_test_bind, [Key2]),
     ok.
 
 fire_and_forget(_Config) ->
@@ -267,7 +275,7 @@ fire_and_forget(_Config) ->
 collection_types(_Config) ->
     CreationQ = <<"CREATE TABLE erlang_driver_test.entries3(key varchar, numbers list<int>, names set<varchar>, phones map<int, varchar>, PRIMARY KEY(key));">>,
     ct:log("Executing : ~s~n", [CreationQ]),
-    {ok, []} = erlcass:query(CreationQ),
+    {ok, [], []} = erlcass:query(CreationQ),
 
     Key2 = <<"somekeyhere_2">>,
     Key3 = <<"somekeyhere_3">>,
@@ -276,48 +284,49 @@ collection_types(_Config) ->
     Map = [{100, <<"418-123-4545">>}, {200, <<"555-555-5555">>}],
     InsertQ = <<"INSERT INTO erlang_driver_test.entries3(key, numbers, names, phones) values (?, ?, ?, ?);">>,
     SelectQ = <<"SELECT key, numbers, names, phones FROM erlang_driver_test.entries3 WHERE key = ?;">>,
-
+    SelectCols = [{<<"key">>, text}, {<<"numbers">>, {list, int}}, {<<"names">>, {set, text}}, {<<"phones">>, {map, int, text}}],
     ok = erlcass:add_prepare_statement(insert_collection_types, InsertQ),
     ok = erlcass:add_prepare_statement(select_collection_types, SelectQ),
 
-    {ok, []} = erlcass:execute(insert_collection_types, ?BIND_BY_NAME, [
+    {ok, [], []} = erlcass:execute(insert_collection_types, ?BIND_BY_NAME, [
         {<<"key">>, Key2},
         {<<"numbers">>, List},
         {<<"names">>, Set},
         {<<"phones">>, Map}
     ]),
 
-    {ok, []} = erlcass:execute(insert_collection_types, [Key3, List, Set, Map]),
+    {ok, [], []} = erlcass:execute(insert_collection_types, [Key3, List, Set, Map]),
 
-    {ok, [{Key2, List, Set, Map}]} = erlcass:execute(select_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
-    {ok, [{Key3, List, Set, Map}]} = erlcass:execute(select_collection_types, ?BIND_BY_INDEX, [Key3]),
+    {ok, SelectCols, [{Key2, List, Set, Map}]} = erlcass:execute(select_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
+    {ok, SelectCols, [{Key3, List, Set, Map}]} = erlcass:execute(select_collection_types, ?BIND_BY_INDEX, [Key3]),
     ok.
 
 nested_collections(_Config) ->
     CreationQ = <<"CREATE TABLE erlang_driver_test.nested_collections(key varchar, numbers list<frozen<map<int, varchar>>>, PRIMARY KEY(key))">>,
     ct:log("Executing : ~s~n", [CreationQ]),
-    {ok, []} = erlcass:query(CreationQ),
+    {ok, [], []} = erlcass:query(CreationQ),
 
     Key2 = <<"somekeyhere_2">>,
     Key3 = <<"somekeyhere_3">>,
     List = [[{100, <<"418-123-4545">>}, {200, <<"555-555-5555">>}], [{101, <<"1418-123">>}, {201, <<"5555-111">>}]],
     InsertQ = <<"INSERT INTO erlang_driver_test.nested_collections(key, numbers) values (?, ?)">>,
     SelectQ = <<"SELECT key, numbers FROM erlang_driver_test.nested_collections WHERE key = ?">>,
+    SelectCols = [{<<"key">>, text}, {<<"numbers">>, {list, {map, int, text}}}],
 
     ok = erlcass:add_prepare_statement(nest_insert_collection_types, InsertQ),
     ok = erlcass:add_prepare_statement(nest_select_collection_types, SelectQ),
 
-    {ok, []} = erlcass:execute(nest_insert_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}, {<<"numbers">>, List}]),
-    {ok, []} = erlcass:execute(nest_insert_collection_types, [Key3, List]),
+    {ok, [], []} = erlcass:execute(nest_insert_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}, {<<"numbers">>, List}]),
+    {ok, [], []} = erlcass:execute(nest_insert_collection_types, [Key3, List]),
 
-    {ok, [{Key2, List}]} = erlcass:execute(nest_select_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
-    {ok, [{Key3, List}]} = erlcass:execute(nest_select_collection_types, ?BIND_BY_INDEX, [Key3]),
+    {ok, SelectCols, [{Key2, List}]} = erlcass:execute(nest_select_collection_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
+    {ok, SelectCols, [{Key3, List}]} = erlcass:execute(nest_select_collection_types, ?BIND_BY_INDEX, [Key3]),
     ok.
 
 tuples(_Config) ->
     CreationQ = <<"CREATE TABLE erlang_driver_test.tuples (key varchar, item1 frozen<tuple<text, list<int>>>, item2 frozen< tuple< tuple<text, bigint> > >, PRIMARY KEY(key));">>,
     ct:log("Executing : ~s~n", [CreationQ]),
-    {ok, []} = erlcass:query(CreationQ),
+    {ok, [], []} = erlcass:query(CreationQ),
 
     Key2 = <<"somekeyhere_2">>,
     Key3 = <<"somekeyhere_3">>,
@@ -327,20 +336,21 @@ tuples(_Config) ->
 
     InsertQ = <<"INSERT INTO erlang_driver_test.tuples(key, item1, item2) values (?, ?, ?)">>,
     SelectQ = <<"SELECT key, item1, item2 FROM erlang_driver_test.tuples WHERE key = ?">>,
+    SelectCols = [{<<"key">>, text}, {<<"item1">>, {tuple, [text, {list, int}]}}, {<<"item2">>, {tuple, [{tuple, [text, bigint]}]}}],
 
     ok = erlcass:add_prepare_statement(insert_tuple_types, InsertQ),
     ok = erlcass:add_prepare_statement(select_tuple_types, SelectQ),
 
-    {ok, []} = erlcass:execute(insert_tuple_types, ?BIND_BY_NAME, [
+    {ok, [], []} = erlcass:execute(insert_tuple_types, ?BIND_BY_NAME, [
         {<<"key">>, Key2},
         {<<"item1">>, Item1},
         {<<"item2">>, Item2}
     ]),
 
-    {ok, []} = erlcass:execute(insert_tuple_types, [Key3, Item1, Item2]),
+    {ok, [], []} = erlcass:execute(insert_tuple_types, [Key3, Item1, Item2]),
 
-    {ok, [{Key2, Item1, Item2}]} = erlcass:execute(select_tuple_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
-    {ok, [{Key3, Item1, Item2}]} = erlcass:execute(select_tuple_types, ?BIND_BY_INDEX, [Key3]),
+    {ok, SelectCols, [{Key2, Item1, Item2}]} = erlcass:execute(select_tuple_types, ?BIND_BY_NAME, [{<<"key">>, Key2}]),
+    {ok, SelectCols, [{Key3, Item1, Item2}]} = erlcass:execute(select_tuple_types, ?BIND_BY_INDEX, [Key3]),
     ok.
 
 test_udt(_Config) ->
@@ -361,23 +371,23 @@ test_udt(_Config) ->
         {<<"phones">>, [<<"33 6 78 90 12 34">>]}
     ],
 
-    {ok, []} = erlcass:query(<<"CREATE TYPE erlang_driver_test.address (street text, city text, zip_code int, phones set<text>)">>),
-    {ok, []} = erlcass:query(<<"CREATE TYPE erlang_driver_test.fullname (firstname text, lastname text)">>),
-    {ok, []} = erlcass:query(<<"CREATE TABLE erlang_driver_test.users (id uuid PRIMARY KEY, name frozen <fullname>, direct_reports set<frozen <fullname>>, addresses map<text, frozen <address>>)">>),
+    {ok, [], []} = erlcass:query(<<"CREATE TYPE erlang_driver_test.address (street text, city text, zip_code int, phones set<text>)">>),
+    {ok, [], []} = erlcass:query(<<"CREATE TYPE erlang_driver_test.fullname (firstname text, lastname text)">>),
+    {ok, [], []} = erlcass:query(<<"CREATE TABLE erlang_driver_test.users (id uuid PRIMARY KEY, name frozen <fullname>, direct_reports set<frozen <fullname>>, addresses map<text, frozen <address>>)">>),
 
     ok = erlcass:add_prepare_statement(insert_udt, <<"INSERT INTO erlang_driver_test.users (id, name) VALUES (?, ?)">>),
     ok = erlcass:add_prepare_statement(update_address_udt, <<"UPDATE erlang_driver_test.users SET addresses = addresses + ? WHERE id=?;">>),
     ok = erlcass:add_prepare_statement(select_name_udt, <<"SELECT name FROM erlang_driver_test.users WHERE id=?">>),
     ok = erlcass:add_prepare_statement(select_last_name_udt, <<"SELECT name.lastname FROM erlang_driver_test.users WHERE id= ?">>),
 
-    {ok, []} = erlcass:execute(insert_udt, [UserId, Username]),
-    {ok, []} = erlcass:execute(update_address_udt, [[{<<"home">>, Address}], UserId]),
+    {ok, [], []} = erlcass:execute(insert_udt, [UserId, Username]),
+    {ok, [], []} = erlcass:execute(update_address_udt, [[{<<"home">>, Address}], UserId]),
 
-    {ok, [{Username}]} = erlcass:execute(select_name_udt, [UserId]),
-    {ok, [{Lname}]} = erlcass:execute(select_last_name_udt, [UserId]).
+    {ok, _, [{Username}]} = erlcass:execute(select_name_udt, [UserId]),
+    {ok, _, [{Lname}]} = erlcass:execute(select_last_name_udt, [UserId]).
 
 batches(_Config) ->
-    {ok, []} = erlcass:query(<<"TRUNCATE erlang_driver_test.entries1;">>),
+    {ok, [], []} = erlcass:query(<<"TRUNCATE erlang_driver_test.entries1;">>),
 
     InsertStatement = <<"INSERT INTO erlang_driver_test.entries1(id, age, email) VALUES (?, ?, ?)">>,
     Id2 = <<"id_2">>,
@@ -390,12 +400,13 @@ batches(_Config) ->
     {ok, Stm2} = erlcass:bind_prepared_statement(insert_prep),
     ok = erlcass:bind_prepared_params_by_name(Stm2, [{<<"id">>, Id2}, {<<"age">>, Age2}, {<<"email">>, Email2}]),
 
-    {ok, []} = erlcass:batch_execute(?CASS_BATCH_TYPE_LOGGED, [Stm1, Stm2], [
+    {ok, [], []} = erlcass:batch_execute(?CASS_BATCH_TYPE_LOGGED, [Stm1, Stm2], [
         {consistency_level, ?CASS_CONSISTENCY_QUORUM},
         {serial_consistency_level, ?CASS_CONSISTENCY_LOCAL_SERIAL}
     ]),
 
-    {ok, Result} = erlcass:query(<<"SELECT id, age, email FROM erlang_driver_test.entries1">>),
+    Cols = [{<<"id">>, text}, {<<"age">>, int}, {<<"email">>, text}],
+    {ok, Cols, Result} = erlcass:query(<<"SELECT id, age, email FROM erlang_driver_test.entries1">>),
     ListLength = 2,
     ListLength = length(Result),
     ok.
@@ -404,7 +415,7 @@ erlcass_crash(_Config) ->
     exit(whereis(erlcass), kill),
     Key3 = <<"somekeyhere_3">>,
     timer:sleep(2000),
-    {ok, _} = erlcass:execute(select_tuple_types, ?BIND_BY_INDEX, [Key3]),
+    {ok, _, _} = erlcass:execute(select_tuple_types, ?BIND_BY_INDEX, [Key3]),
     ok.
 
 uuid_testing(_Config) ->
@@ -432,6 +443,6 @@ get_metrics(_Config) ->
     ok.
 
 drop_keyspace(_Config) ->
-    {ok, []} = erlcass:query(<<"DROP KEYSPACE erlang_driver_test">>).
+    {ok, [], []} = erlcass:query(<<"DROP KEYSPACE erlang_driver_test">>).
 
 


### PR DESCRIPTION
This returns result of the form
```
{ok, 
  {
    [{row1...}, {row2...}], 
    [{<<"column_name">>, type}, ]
  }
}
```
With this form of result, I can construct a map.