### PR TITLE
add hex package metadata

### DIFF
--- a/src/erlcass.app.src
+++ b/src/erlcass.app.src
@@ -1,8 +1,11 @@
 {application, erlcass, [
     {description, "ErlCass - Erlang Cassandra Driver"},
-    {vsn, "3.1"},
+    {vsn, "3.1.0"},
     {registered, []},
     {applications, [kernel, stdlib, lager]},
     {mod, {erlcass_app, []}},
-    {env, []}
+    {env, []},
+    {maintainers, ["Silviu Caragea"]},
+    {licenses, ["MIT"]},
+    {links,[{"Github","https://github.com/silviucpp/erlcass"}]}
 ]}.


### PR DESCRIPTION
Related with #26. Once this is merged, this repository is ready to be published as a Hex package for use with other Erlang and Elixir projects.