### PR TITLE
install PPA only on ubuntu 14.04

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -46,10 +46,24 @@ case $OS in
             Ubuntu)
 
                 echo "Linux, Ubuntu"
-
-                sudo apt-add-repository -y ppa:linuxjedi/ppa
-                sudo apt-get -y update
-                sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
+                # check ubuntu version
+                $ubuntu_version = $(lsb_release -sr)
+                if [[ $ubuntu_version == "14.04" ]]; then
+                    # system is Ubuntu 14.04, need to install PPA and possibly override libuv
+                    sudo apt-add-repository -y ppa:linuxjedi/ppa
+                    sudo apt-get -y update
+                    sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
+                else
+                    # system is assumed to be more recent than 14.04, check if libuv exists
+                    # if it doesn't, install it.
+                    OUTPUT=`ldconfig -p | grep libuv`
+                    if [[ $(echo $OUTPUT) != "" ]]
+                        then echo "libuv has already been installed"
+                    else
+                        sudo apt-get -y update
+                        sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
+                    fi
+                fi
             ;;
 
             *) echo "Your system $KERNEL is not supported"

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -51,19 +51,9 @@ case $OS in
                 if [[ $ubuntu_version == "14.04" ]]; then
                     # system is Ubuntu 14.04, need to install PPA and possibly override libuv
                     sudo apt-add-repository -y ppa:linuxjedi/ppa
-                    sudo apt-get -y update
-                    sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
-                else
-                    # system is assumed to be more recent than 14.04, check if libuv exists
-                    # if it doesn't, install it.
-                    OUTPUT=`ldconfig -p | grep libuv`
-                    if [[ $(echo $OUTPUT) != "" ]]
-                        then echo "libuv has already been installed"
-                    else
-                        sudo apt-get -y update
-                        sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
-                    fi
                 fi
+                sudo apt-get -y update
+                sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
             ;;
 
             *) echo "Your system $KERNEL is not supported"


### PR DESCRIPTION
These changes should fix #31 .
`lsb_release -sr` returns the exact version (e.g. 16.04, 18.04 or 14.04) so we can use it to conditionally add the PPA only in 14.04.

For the remaining cases, I've added an additional check: if libuv exists, there is no need to try and install it again.