### PR TITLE
Update build_deps script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
       - libssl-dev
 language: erlang
 otp_release:
-    - 21
-    - 20
-    - 19
+    - 21.1
+    - 20.3.8.5
+    - 19.3
 script:
     - rebar3 compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
       - libssl-dev
 language: erlang
 otp_release:
-    - 21.1
-    - 20.3
-    - 19.3
+    - 21
+    - 20
+    - 19
 script:
     - rebar3 compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
+dist: xenial
+addons:
+  apt:
+    packages:
+      - g++
+      - make
+      - cmake
+      - libuv1-dev
+      - libssl-dev
 language: erlang
 otp_release:
     - 21.1
     - 20.3
     - 19.3
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: linux
-      dist: xenial
-      sudo: false
 script:
     - rebar3 compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: erlang
+otp_release:
+    - 21.1
+    - 20.3
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: linux
+      dist: xenial
+      sudo: false
+script:
+    - rebar3 compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: erlang
 otp_release:
     - 21.1
     - 20.3
+    - 19.3
 matrix:
   include:
     - os: linux

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := compile
 
-REBAR=rebar
+REBAR=rebar3
 
 # for benchmark
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ErlCass
+[![Build Status](https://travis-ci.org/silviucpp/erlcass.svg?branch=master)](https://travis-ci.org/silviucpp/erlcass)
 
 *An Erlang Cassandra driver, based on [DataStax cpp driver][1] focused on performance.*
 
@@ -13,12 +14,12 @@ This update breaks the compatibility with the other versions. All query results 
 #### How ErlCass affects the Erlang schedulers
 
 It's well known that NIF's can affect the Erlang schedulers performances in case the functions are not returning in less
-than 1-2 ms and blocks the threads. 
+than 1-2 ms and blocks the threads.
 
-Because the DataStax cpp driver is async, `ErlCass` won't block the scheduler threads and all calls to the native 
-functions will return immediately. The DataStax driver use it's own thread pool for managing the requests. 
-Also the responses are received on this threads and sent back to Erlang calling processes using `enif_send` in 
-an async manner. 
+Because the DataStax cpp driver is async, `ErlCass` won't block the scheduler threads and all calls to the native
+functions will return immediately. The DataStax driver use it's own thread pool for managing the requests.
+Also the responses are received on this threads and sent back to Erlang calling processes using `enif_send` in
+an async manner.
 
 #### Benchmark comparing with other drivers
 
@@ -35,9 +36,9 @@ To run the benchmark yourself you should do:
 - create the testing keyspace and tables using `load_test:prepare_load_test_table().`
 - use `make benchmark` as described above
 
-The following test was run on a MacBook Pro with Mac OS Sierra 10.12.6 and the cassandra cluster was running on other 3 
-physical machines in the same LAN. The schema was created using `load_test:prepare_load_test_table` from `benchmarks/load_test.erl`. 
-Basically the schema contains all possible data types and the query is based on a primary key (will return the same 
+The following test was run on a MacBook Pro with Mac OS Sierra 10.12.6 and the cassandra cluster was running on other 3
+physical machines in the same LAN. The schema was created using `load_test:prepare_load_test_table` from `benchmarks/load_test.erl`.
+Basically the schema contains all possible data types and the query is based on a primary key (will return the same
 row all the time which is fine because we test the driver performances and not the server one)
 
 ```erlang
@@ -51,16 +52,16 @@ Where:
 - `REQ`: the number of requests to be sent. Default 100000.
 
 The results for 100 concurrent processes that sends 100k queries. Measured the average time for 3 runs:
- 
+
 | cassandra driver     | Time (ms) | Req/sec  |
 |:--------------------:| ---------:|---------:|
-| [erlcass][8] v3.0    | 1466      | 68212    | 
+| [erlcass][8] v3.0    | 1466      | 68212    |
 | [cqerl][6] v1.0.8    | 11016     | 9077     |
 | [marina][7] 0.2.17   | 1779      | 56221    |
 
 Notes:
 
-- `marina` performs very nice unfortunately you need to tune properly the `backlog_size` and `pool_size` based on the 
+- `marina` performs very nice unfortunately you need to tune properly the `backlog_size` and `pool_size` based on the
 concurrency level you are using. From my test performance degrades a lot if pool size is increased (for example for 100 connections time to complete was 3044 ms instead 1779 ms for 30 connections)
 Also in case te pool is too small you start getting all kind of errors (like no socket available) or in case the backlog is not big enough you get errors as well.
 - `erlcass` seems to have the smallest variation between tests. Results are always in the same range +/- 100 ms. On the other drivers might happened time to time to have bigger variations.
@@ -73,7 +74,7 @@ Changelog is available [here][5].
 
 The application is compatible with both `rebar` or `rebar3`.
 
-In case you receive any error related to compiling of the DataStax driver you can try to run `rebar` with `sudo` in 
+In case you receive any error related to compiling of the DataStax driver you can try to run `rebar` with `sudo` in
 order to install all dependencies. Also you can check [wiki section][2] for more details
 
 ### Data types
@@ -88,9 +89,9 @@ application:start(erlcass).
 
 ### Setting the log level
 
-`Erlcass` is using `lager` for logging the errors. Beside the fact that you can set in lager the desired log level, 
-for better performances it's better to set also in `erlcass` the desired level otherwise there will be a lot of 
-resources consumed by lager to format the messages and then drop them. Also the native driver performances can be 
+`Erlcass` is using `lager` for logging the errors. Beside the fact that you can set in lager the desired log level,
+for better performances it's better to set also in `erlcass` the desired level otherwise there will be a lot of
+resources consumed by lager to format the messages and then drop them. Also the native driver performances can be
 affected because of the time spent in generating the logs and sending them from C++ into Erlang.  
 
 Available Log levels are:
@@ -105,7 +106,7 @@ Available Log levels are:
 -define(CASS_LOG_TRACE, 6).
 ```
 
-In order to change the log level for the native driver you need to set the `log_level` environment variable for 
+In order to change the log level for the native driver you need to set the `log_level` environment variable for
 `erlcass` into your app config file, example: `{log_level, 3}`.
 
 ### Setting the cluster options
@@ -136,7 +137,7 @@ The cluster options can be set inside your `app.config` file under the `cluster_
 
 - Use `token_aware_routing` and `latency_aware_routing`
 - Don't use `number_threads_io` bigger than the number of your cores.
-- Use `tcp_nodelay` and also enable `tcp_keepalive` 
+- Use `tcp_nodelay` and also enable `tcp_keepalive`
 
 All available options are described in the following [wiki section][4].
 
@@ -149,14 +150,14 @@ ok = erlcass:add_prepare_statement(select_blogpost,
                                    <<"select * from blogposts where domain = ? LIMIT 1">>),
 ```
 
-In case you want to overwrite the default consistency level for that prepare statement use a tuple for the 
+In case you want to overwrite the default consistency level for that prepare statement use a tuple for the
 query argument: `{Query, ConsistencyLevelHere}`
 
 Also this is possible using `{Query, Options}` where options is a proplist with the following options supported:
 
 - `consistency_level` - If it's missing the statement will be executed using the default consistency level value.
-- `serial_consistency_level` - This consistency can only be either `?CASS_CONSISTENCY_SERIAL` or 
-`?CASS_CONSISTENCY_LOCAL_SERIAL` and if not present, it defaults to `?CASS_CONSISTENCY_SERIAL`. This option will be 
+- `serial_consistency_level` - This consistency can only be either `?CASS_CONSISTENCY_SERIAL` or
+`?CASS_CONSISTENCY_LOCAL_SERIAL` and if not present, it defaults to `?CASS_CONSISTENCY_SERIAL`. This option will be
 ignored for anything else that a conditional update/insert.
 
 Example:
@@ -178,7 +179,7 @@ ok = erlcass:add_prepare_statement(insert_blogpost, {
 
 ### Run a prepared statement query
 
-You can bind the parameters in 2 ways: by name and by index. You can use `?BIND_BY_INDEX` and `?BIND_BY_NAME` from 
+You can bind the parameters in 2 ways: by name and by index. You can use `?BIND_BY_INDEX` and `?BIND_BY_NAME` from
 `execute/3` in order to specify the desired method. By default is binding by index
 
 Example:
@@ -207,8 +208,8 @@ erlcass:execute(identifier, [<<"collection_key_here">>, <<"collection_value_here
 %bind by name
 
 erlcass:execute(insert_test_bind, ?BIND_BY_NAME, [
-    {<<"key(value)">>, CollectionIndex1}, 
-    {<<"value(value)">>, CollectionValue1}, 
+    {<<"key(value)">>, CollectionIndex1},
+    {<<"value(value)">>, CollectionValue1},
     {<<"key">>, Key1}
 ]),
 ```
@@ -217,10 +218,10 @@ erlcass:execute(insert_test_bind, ?BIND_BY_NAME, [
 
 For blocking operations use `erlcass:execute`, for async execution use : `erlcass:async_execute`.
 
-The blocking operation the calling process will block (still async into the native code in order to avoid 
+The blocking operation the calling process will block (still async into the native code in order to avoid
 freezing of the VM threads) until will get the result from the cluster.
 
-In case of an async execution the calling process will receive a message of the following format: 
+In case of an async execution the calling process will receive a message of the following format:
 `{execute_statement_result, Tag, Result}` when the data from the server was retrieved.
 
 For example:
@@ -236,10 +237,10 @@ For example:
 ### Non prepared statements queries
 
 In order to run queries that you don't want to run them as prepared statements you can use:
-`query/1`, `query_async/1` or `query_new_statement/1` (in order to create a query statement that can be executed into a 
-batch query along other prepared or not prepared statements) 
+`query/1`, `query_async/1` or `query_new_statement/1` (in order to create a query statement that can be executed into a
+batch query along other prepared or not prepared statements)
 
-The same rules apply for setting the desired consistency level as on prepared statements (see Add prepare statement 
+The same rules apply for setting the desired consistency level as on prepared statements (see Add prepare statement
 section).
 
 ```erlang
@@ -263,8 +264,8 @@ The second one is a list of statements (prepared or normal statements) that need
 The third argument is a list of options in `{Key, Value}` format (proplist):
 
 - `consistency_level` - If it's missing the batch will be executed using the default consistency level value.
-- `serial_consistency_level` - That consistency can only be either `?CASS_CONSISTENCY_SERIAL` or 
-`?CASS_CONSISTENCY_LOCAL_SERIAL` and if not present, it defaults to `?CASS_CONSISTENCY_SERIAL`. This option will be 
+- `serial_consistency_level` - That consistency can only be either `?CASS_CONSISTENCY_SERIAL` or
+`?CASS_CONSISTENCY_LOCAL_SERIAL` and if not present, it defaults to `?CASS_CONSISTENCY_SERIAL`. This option will be
 ignored for anything else that a conditional update/insert.
 
 Example:
@@ -294,11 +295,11 @@ ok = erlcass:batch_execute(?CASS_BATCH_TYPE_LOGGED, [Stm1, Stm2], [
 
 ### Working with date, time fields:
 
-- `erlcass_time:date_from_epoch(EpochSecs)` -> Converts a unix timestamp (in seconds) to the Cassandra `date` type. 
+- `erlcass_time:date_from_epoch(EpochSecs)` -> Converts a unix timestamp (in seconds) to the Cassandra `date` type.
 The `date` type represents the number of days since the Epoch (1970-01-01) with the Epoch centered at the value 2^31.
-- `erlcass_time:time_from_epoch(EpochSecs)` -> Converts a unix timestamp (in seconds) to the Cassandra `time` type. 
+- `erlcass_time:time_from_epoch(EpochSecs)` -> Converts a unix timestamp (in seconds) to the Cassandra `time` type.
 The `time` type represents the number of nanoseconds since midnight (range 0 to 86399999999999).
-- `erlcass_time:date_time_to_epoch(Date, Time)` -> Combines the Cassandra `date` and `time` types to Epoch time 
+- `erlcass_time:date_time_to_epoch(Date, Time)` -> Combines the Cassandra `date` and `time` types to Epoch time
 in seconds. Returns Epoch time in seconds. Negative times are possible if the date occurs before the Epoch (1970-1-1).
 
 ### Getting metrics
@@ -334,7 +335,7 @@ In order to get metrics from the native driver you can use `erlcass:get_metrics(
 
 ### Low level methods
 
-Each query requires an internal statement (prepared or not). You can reuse the same statement object for multiple 
+Each query requires an internal statement (prepared or not). You can reuse the same statement object for multiple
 queries performed in the same process.
 
 ##### Getting a statement reference for a prepared statement query

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -47,8 +47,8 @@ case $OS in
 
                 echo "Linux, Ubuntu"
                 # check ubuntu version
-                $ubuntu_version=$(lsb_release -sr)
-                if [[ $ubuntu_version == "14.04" ]]; then
+                UBUNTU_VSN=$(lsb_release -sr)
+                if [[ $UBUNTU_VSN == "14.04" ]]; then
                     # system is Ubuntu 14.04, need to install PPA and possibly override libuv
                     sudo apt-add-repository -y ppa:linuxjedi/ppa
                     sudo apt-get -y update

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -51,9 +51,13 @@ case $OS in
                 if [[ $ubuntu_version == "14.04" ]]; then
                     # system is Ubuntu 14.04, need to install PPA and possibly override libuv
                     sudo apt-add-repository -y ppa:linuxjedi/ppa
+                    sudo apt-get -y update
+                    sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
+                else
+                    # make sure we request libuv1-dev and not libuv-dev
+                    sudo apt-get -y update
+                    sudo apt-get -y install g++ make cmake libuv1-dev libssl-dev
                 fi
-                sudo apt-get -y update
-                sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
             ;;
 
             *) echo "Your system $KERNEL is not supported"

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -51,13 +51,12 @@ case $OS in
                 if [[ $UBUNTU_VSN == "14.04" ]]; then
                     # system is Ubuntu 14.04, need to install PPA and possibly override libuv
                     sudo apt-add-repository -y ppa:linuxjedi/ppa
-                    sudo apt-get -y update
-                    sudo apt-get -y install g++ make cmake libuv-dev libssl-dev
+                    LIBUDEV_PACKAGE_NAME=libuv-dev
                 else
-                    # make sure we request libuv1-dev and not libuv-dev
-                    sudo apt-get -y update
-                    sudo apt-get -y install g++ make cmake libuv1-dev libssl-dev
+                    LIBUDEV_PACKAGE_NAME=libuv1-dev
                 fi
+                sudo apt-get -y update
+                sudo apt-get -y install g++ make cmake libssl-dev $LIBUDEV_PACKAGE_NAME
             ;;
 
             *) echo "Your system $KERNEL is not supported"

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -47,7 +47,7 @@ case $OS in
 
                 echo "Linux, Ubuntu"
                 # check ubuntu version
-                $ubuntu_version = $(lsb_release -sr)
+                $ubuntu_version=$(lsb_release -sr)
                 if [[ $ubuntu_version == "14.04" ]]; then
                     # system is Ubuntu 14.04, need to install PPA and possibly override libuv
                     sudo apt-add-repository -y ppa:linuxjedi/ppa

--- a/rebar.config
+++ b/rebar.config
@@ -4,11 +4,11 @@
 {plugins, [rebar3_hex]}.
 
 {deps, [
-    {lager, "3.6.1"}
+    {lager, "~>3.6"}
 ]}.
 
 {erl_opts, [
-    warnings_as_errors ,
+    warnings_as_errors,
     warn_export_all,
     {parse_transform, lager_transform}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.6.1">>},0}]}.
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"9D29C5FF7F926D25ECD9899990867C9152DCF34EEE65BAC8EC0DFC0D16A26E0C">>}]}
+ {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>}]}
 ].


### PR DESCRIPTION
Changes made:

- Add travis script (tests compilation on Erlang 19, 20 and 21)
- Use rebar3 as the default build tool in the Makefile (rebar has been deprecated)
- Update `lager` dependency version
- Fix bug on `build_deps.sh` (space missing in command)
- Make appropriate changes to `build_deps.sh` so that the correct libuv version is always installed.