### PR TITLE
Update erlcass with keyspace init & pagination support

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 DEPS_LOCATION=_build/deps
 
@@ -61,8 +61,8 @@ case $OS in
 
             *) echo "Your system $KERNEL is not supported"
         esac
-        export CFLAGS="-fPIC -Wno-class-memaccess"
-		export CXXFLAGS="-fPIC -Wno-class-memaccess"
+        export CFLAGS="-fPIC"
+        export CXXFLAGS="-fPIC -Wno-class-memaccess"
     ;;
 
     Darwin)
@@ -91,5 +91,5 @@ popd
 mkdir -p $DEPS_LOCATION/cpp-driver/build
 pushd $DEPS_LOCATION/cpp-driver/build
 cmake .. -DCASS_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=RELEASE
-make -j 12
+make -j ${ERLCASS_DEPS_CORES:-12}
 popd

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -26,6 +26,7 @@ ifeq ($(UNAME_SYS), darwin)
 				-Wl,-U,_enif_is_tuple \
 				-Wl,-U,_enif_is_atom \
 				-Wl,-U,_enif_is_list \
+				-Wl,-U,_enif_get_atom \
 				-Wl,-U,_enif_get_int \
 				-Wl,-U,_enif_get_list_cell \
 				-Wl,-U,_enif_get_resource \
@@ -57,7 +58,7 @@ else
 	CXXFLAGS+= -Wno-class-memaccess
 endif
 
-CXXFLAGS+=  -g -std=c++11 -Wextra -Werror -fno-rtti \
+CXXFLAGS+= -O3 -std=c++11 -Wextra -Werror -fno-rtti \
 			-Wno-unused-local-typedefs -Wno-unused-parameter -Wno-missing-field-initializers \
             -I $(BASEDIR)/_build/deps/cpp-driver/include \
             -I $(BASEDIR)/_build/deps/cpp-driver/src \

--- a/c_src/constants.cc
+++ b/c_src/constants.cc
@@ -34,6 +34,8 @@ const char kAtomSessionConnected[] = "session_connected";
 const char kAtomSessionClosed[] = "session_closed";
 const char kAtomPreparedStatementResult[] = "prepared_statement_result";
 const char kAtomExecuteStatementResult[] = "execute_statement_result";
+const char kAtomPagedExecuteStatementResult[] = "paged_execute_statement_result";
+const char kAtomPagedExecuteStatementResultHasMore[] = "paged_execute_statement_result_has_more";
 const char kAtomLogMessageReceived[] = "log_message_recv";
 
 // data types

--- a/c_src/constants.h
+++ b/c_src/constants.h
@@ -35,6 +35,8 @@ extern const char kAtomSessionConnected[];
 extern const char kAtomSessionClosed[];
 extern const char kAtomPreparedStatementResult[];
 extern const char kAtomExecuteStatementResult[];
+extern const char kAtomPagedExecuteStatementResult[];
+extern const char kAtomPagedExecuteStatementResultHasMore[];
 extern const char kAtomLogMessageReceived[];
 
 // data types

--- a/c_src/erlcass.cc
+++ b/c_src/erlcass.cc
@@ -37,6 +37,8 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     ATOMS.atomSessionClosed = make_atom(env, erlcass::kAtomSessionClosed);
     ATOMS.atomPreparedStatementResult = make_atom(env, erlcass::kAtomPreparedStatementResult);
     ATOMS.atomExecuteStatementResult = make_atom(env, erlcass::kAtomExecuteStatementResult);
+    ATOMS.atomPagedExecuteStatementResult = make_atom(env, erlcass::kAtomPagedExecuteStatementResult);
+    ATOMS.atomPagedExecuteStatementResultHasMore = make_atom(env, erlcass::kAtomPagedExecuteStatementResultHasMore);
     ATOMS.atomLogMessageReceived = make_atom(env, erlcass::kAtomLogMessageReceived);
 
     // data types
@@ -183,7 +185,9 @@ static ErlNifFunc nif_funcs[] =
     {"cass_prepared_bind", 1, nif_cass_prepared_bind},
     {"cass_statement_new", 1, nif_cass_statement_new},
     {"cass_statement_bind_parameters", 3, nif_cass_statement_bind_parameters},
+    {"cass_statement_set_paging_size", 2, nif_cass_statement_set_paging_size},
     {"cass_session_execute", 5, nif_cass_session_execute},
+    {"cass_session_execute_paged", 5, nif_cass_session_execute_paged},
     {"cass_session_execute_batch", 5, nif_cass_session_execute_batch},
     {"cass_session_get_metrics", 1, nif_cass_session_get_metrics},
 

--- a/c_src/erlcass.h
+++ b/c_src/erlcass.h
@@ -23,6 +23,8 @@ struct atoms
     ERL_NIF_TERM atomSessionClosed;
     ERL_NIF_TERM atomPreparedStatementResult;
     ERL_NIF_TERM atomExecuteStatementResult;
+    ERL_NIF_TERM atomPagedExecuteStatementResult;
+    ERL_NIF_TERM atomPagedExecuteStatementResultHasMore;
     ERL_NIF_TERM atomLogMessageReceived;
 
     // data types

--- a/c_src/nif_cass_session.cc
+++ b/c_src/nif_cass_session.cc
@@ -22,6 +22,7 @@ struct callback_info
     ErlNifPid pid;
     ERL_NIF_TERM arguments;
     bool fire_and_forget;
+    CassStatement* paged_statment;
 };
 
 struct callback_statement_info
@@ -41,6 +42,7 @@ callback_info* callback_info_alloc(ErlNifEnv* env, const ErlNifPid& pid, ERL_NIF
     callback->env = enif_alloc_env();
     callback->arguments = enif_make_copy(callback->env, arg);
     callback->fire_and_forget = false;
+    callback->paged_statment = NULL;
     return callback;
 }
 
@@ -50,6 +52,7 @@ callback_info* callback_info_alloc(ErlNifEnv* env, ERL_NIF_TERM identifier)
     callback->env = enif_alloc_env();
     callback->arguments = enif_make_copy(callback->env, identifier);
     callback->fire_and_forget = true;
+    callback->paged_statment = NULL;
     return callback;
 }
 
@@ -135,6 +138,8 @@ void on_statement_executed(CassFuture* future, void* user_data)
 {
     callback_info* cb = static_cast<callback_info*>(user_data);
 
+    cass_bool_t has_more_pages = cass_false;
+
     if(cb->fire_and_forget)
     {
         // we only log the response in case it's an error
@@ -164,10 +169,27 @@ void on_statement_executed(CassFuture* future, void* user_data)
         {
             const CassResult* cassResult = cass_future_get_result(future);
             result = cass_result_to_erlang_term(cb->env, cassResult);
+            if (cb->paged_statment != NULL) {
+                /* Check to see if there are more pages remaining for this result */
+                has_more_pages = cass_result_has_more_pages(cassResult);
+
+                if (has_more_pages) {
+                    /* If there are more pages we need to set the position for the next execute */
+                    cass_statement_set_paging_state(cb->paged_statment, cassResult);
+                }
+            }
             cass_result_free(cassResult);
         }
 
-        enif_send(NULL, &cb->pid, cb->env, enif_make_tuple3(cb->env, ATOMS.atomExecuteStatementResult, cb->arguments, result));
+        if (cb->paged_statment != NULL) {
+            if (!has_more_pages) {
+                enif_send(NULL, &cb->pid, cb->env, enif_make_tuple3(cb->env, ATOMS.atomPagedExecuteStatementResult, cb->arguments, result));
+            } else {
+                enif_send(NULL, &cb->pid, cb->env, enif_make_tuple3(cb->env, ATOMS.atomPagedExecuteStatementResultHasMore, cb->arguments, result));
+            }
+        } else {
+            enif_send(NULL, &cb->pid, cb->env, enif_make_tuple3(cb->env, ATOMS.atomExecuteStatementResult, cb->arguments, result));
+        }
     }
 
     callback_info_free(cb);
@@ -325,6 +347,47 @@ ERL_NIF_TERM nif_cass_session_execute(ErlNifEnv* env, int argc, const ERL_NIF_TE
 
     if(callback == NULL)
         return make_error(env, erlcass::kFailedToCreateCallbackInfoMsg);
+
+    CassFuture* future = cass_session_execute(enif_session->session, stm);
+    CassError error = cass_future_set_callback(future, on_statement_executed, callback);
+    cass_future_free(future);
+    return cass_error_to_nif_term(env, error);
+}
+
+ERL_NIF_TERM nif_cass_session_execute_paged(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    cassandra_data* data = static_cast<cassandra_data*>(enif_priv_data(env));
+
+    enif_cass_session * enif_session = NULL;
+
+    if(!enif_get_resource(env, argv[1], data->resCassSession, (void**) &enif_session))
+        return make_badarg(env);
+
+    CassStatement* stm = get_statement(env, data->resCassStatement, argv[2]);
+
+    if(stm == NULL)
+        return make_badarg(env);
+
+    callback_info* callback = NULL;
+
+    if(!enif_is_identical(ATOMS.atomNull, argv[3]))
+    {
+        ErlNifPid pid;
+
+        if(enif_get_local_pid(env, argv[3], &pid) == 0)
+            return make_badarg(env);
+
+        callback = callback_info_alloc(env, pid, argv[4]);
+    }
+    else
+    {
+        return make_badarg(env);
+    }
+
+    if(callback == NULL)
+        return make_error(env, erlcass::kFailedToCreateCallbackInfoMsg);
+
+    callback->paged_statment = stm;
 
     CassFuture* future = cass_session_execute(enif_session->session, stm);
     CassError error = cass_future_set_callback(future, on_statement_executed, callback);

--- a/c_src/nif_cass_session.h
+++ b/c_src/nif_cass_session.h
@@ -9,6 +9,7 @@ ERL_NIF_TERM nif_cass_session_connect(ErlNifEnv* env, int argc, const ERL_NIF_TE
 ERL_NIF_TERM nif_cass_session_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_session_prepare(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_session_execute(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM nif_cass_session_execute_paged(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_session_execute_batch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_session_get_metrics(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_session_get_schema_metadata(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/c_src/nif_cass_statement.cc
+++ b/c_src/nif_cass_statement.cc
@@ -179,3 +179,22 @@ ERL_NIF_TERM nif_cass_statement_bind_parameters(ErlNifEnv* env, int argc, const 
 
     return bind_prepared_statement_params(env, enif_stm->statement, bind_type, argv[2]);
 }
+
+ERL_NIF_TERM nif_cass_statement_set_paging_size(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    cassandra_data* data = static_cast<cassandra_data*>(enif_priv_data(env));
+
+    enif_cass_statement * enif_stm = NULL;
+
+    if(!enif_get_resource(env, argv[0], data->resCassStatement, (void**) &enif_stm))
+        return make_badarg(env);
+
+    int page_size = 0;
+
+    if((!enif_get_int(env, argv[1], &page_size)) || (page_size < 1))
+        return make_badarg(env);
+
+    cass_statement_set_paging_size(enif_stm->statement, page_size);
+
+    return ATOMS.atomOk;
+}

--- a/c_src/nif_cass_statement.h
+++ b/c_src/nif_cass_statement.h
@@ -8,6 +8,7 @@ CassStatement* get_statement(ErlNifEnv* env, ErlNifResourceType* resource_type, 
 ERL_NIF_TERM nif_cass_statement_new(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_cass_statement_new(ErlNifEnv* env, ErlNifResourceType* resource_type, const CassPrepared* prep, const ConsistencyLevelOptions& consistency);
 ERL_NIF_TERM nif_cass_statement_bind_parameters(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM nif_cass_statement_set_paging_size(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 void nif_cass_statement_free(ErlNifEnv* env, void* obj);
 
 #endif  // C_SRC_NIF_CASS_STATEMENT_H_

--- a/c_src/nif_utils.cc
+++ b/c_src/nif_utils.cc
@@ -54,6 +54,11 @@ bool get_bstring(ErlNifEnv* env, ERL_NIF_TERM term, ErlNifBinary* bin)
     return enif_inspect_iolist_as_binary(env, term, bin);
 }
 
+int get_atom(ErlNifEnv* env, ERL_NIF_TERM term, char* buf, size_t buffer_size)
+{
+    return enif_get_atom(env, term, buf, buffer_size, ERL_NIF_LATIN1);
+}
+
 bool get_boolean(ERL_NIF_TERM term, cass_bool_t* val)
 {
     if(enif_is_identical(term, ATOMS.atomTrue))

--- a/c_src/nif_utils.h
+++ b/c_src/nif_utils.h
@@ -34,6 +34,7 @@ ERL_NIF_TERM parse_consistency_level_options(ErlNifEnv* env, ERL_NIF_TERM option
 ERL_NIF_TERM parse_query_term(ErlNifEnv* env, ERL_NIF_TERM qterm, QueryTerm* q);
 
 bool get_bstring(ErlNifEnv* env, ERL_NIF_TERM term, ErlNifBinary* bin);
+int  get_atom(ErlNifEnv* env, ERL_NIF_TERM term, char* buf, size_t buffer_size);
 bool get_boolean(ERL_NIF_TERM term, cass_bool_t* val);
 
 #endif  // C_SRC_NIF_UTILS_H_

--- a/include/erlcass_internals.hrl
+++ b/include/erlcass_internals.hrl
@@ -25,4 +25,4 @@
 % timeouts
 
 -define(RESPONSE_TIMEOUT, 20000).
--define(CONNECT_TIMEOUT, 5000).
+-define(CONNECT_TIMEOUT, 15000).

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{pre_hooks, [{"(linux|darwin)", compile, "make nif_compile CPP_DRIVER_REV=3a5d3a50299fafc9c02c2dd42447e617593a19e9"}]}.
+{pre_hooks, [{"(linux|darwin)", compile, "make nif_compile CPP_DRIVER_REV=c97dd437c3730421f006dc4f2e36b533e405d357"}]}.
 {post_hooks, [{"(linux|darwin)", clean, "make nif_clean"}]}.
 
 {project_plugins, [rebar3_hex]}.

--- a/src/erlcass.erl
+++ b/src/erlcass.erl
@@ -22,6 +22,7 @@
     % prepared statements
 
     add_prepare_statement/2,
+    set_paging_size/2,
     async_execute/1,
     async_execute/2,
     async_execute/3,
@@ -30,6 +31,9 @@
     execute/1,
     execute/2,
     execute/3,
+    async_execute_paged/2,
+    async_execute_paged/3,
+    execute_paged/2,
 
     % batch
 
@@ -61,13 +65,14 @@
 -record(erlcass_stm, {session, stm}).
 -record(state, {session}).
 
--type query()           :: binary() | {binary(), integer()} | {binary(), list()}.
--type statement_ref()   :: #erlcass_stm{}.
--type bind_type()       :: ?BIND_BY_INDEX | ?BIND_BY_NAME.
--type batch_type()      :: ?CASS_BATCH_TYPE_LOGGED | ?CASS_BATCH_TYPE_UNLOGGED | ?CASS_BATCH_TYPE_COUNTER.
--type tag()             :: reference().
--type recv_pid()        :: pid() | null.
--type query_result()    :: ok | {ok, list(), list()} | {error, reason()}.
+-type query()               :: binary() | {binary(), integer()} | {binary(), list()}.
+-type statement_ref()       :: #erlcass_stm{}.
+-type bind_type()           :: ?BIND_BY_INDEX | ?BIND_BY_NAME.
+-type batch_type()          :: ?CASS_BATCH_TYPE_LOGGED | ?CASS_BATCH_TYPE_UNLOGGED | ?CASS_BATCH_TYPE_COUNTER.
+-type tag()                 :: reference().
+-type recv_pid()            :: pid() | null.
+-type query_result()        :: ok | {ok, list(), list()} | {error, reason()}.
+-type paged_query_result()  :: {ok, list(), list(), boolean()} | {error, reason()}.
 
 -spec get_metrics() ->
     {ok, list()} | {error, reason()}.
@@ -258,6 +263,48 @@ execute(Identifier, BindType, Params) ->
             Error
     end.
 
+-spec set_paging_size(statement_ref(), integer()) ->
+    ok | {error, reason()}.
+
+set_paging_size(Stm, PageSize) ->
+    erlcass_nif:cass_statement_set_paging_size(Stm#erlcass_stm.stm, PageSize).
+
+-spec async_execute_paged(statement_ref(), atom()) ->
+    {ok, tag()} | {error, reason()}.
+
+async_execute_paged(Stm, Identifier) ->
+    Tag = make_ref(),
+    ReceiverPid = self(),
+    case erlcass_nif:cass_session_execute_paged(get_identifier(ReceiverPid, Identifier), Stm#erlcass_stm.session, Stm#erlcass_stm.stm, ReceiverPid, Tag) of
+        ok ->
+            {ok, Tag};
+        Error ->
+            Error
+    end.
+
+-spec async_execute_paged(statement_ref(), atom(), recv_pid()) ->
+    {ok, tag()} | {error, reason()}.
+
+async_execute_paged(Stm, Identifier, ReceiverPid) ->
+    Tag = make_ref(),
+    case erlcass_nif:cass_session_execute_paged(get_identifier(ReceiverPid, Identifier), Stm#erlcass_stm.session, Stm#erlcass_stm.stm, ReceiverPid, Tag) of
+        ok ->
+            {ok, Tag};
+        Error ->
+            Error
+    end.
+
+-spec execute_paged(statement_ref(), atom()) ->
+    paged_query_result().
+
+execute_paged(Stm, Identifier) ->
+    case async_execute_paged(Stm, Identifier) of
+        {ok, Tag} ->
+            receive_paged_response(Tag);
+        Error ->
+            Error
+    end.
+
 -spec batch_async_execute(batch_type(), list(), list()) ->
     {ok, tag()} | {error, reason()}.
 
@@ -368,13 +415,26 @@ receive_response(Tag) ->
         {error, timeout}
     end.
 
-do_connect(Session, Pid) ->
-    case erlcass_utils:get_env(keyspace) of
-        {ok, Keyspace} ->
-            erlcass_nif:cass_session_connect(Session, Pid, Keyspace);
-        _ ->
-            erlcass_nif:cass_session_connect(Session, Pid)
+receive_paged_response(Tag) ->
+    receive
+        {paged_execute_statement_result, Tag, {ok, Columns, Rows}} ->
+            {ok, Columns, Rows, false};
+        {paged_execute_statement_result_has_more, Tag, {ok, Columns, Rows}} ->
+            {ok, Columns, Rows, true};
+        {paged_execute_statement_result, Tag, Error} ->
+            Error;
+        {paged_execute_statement_result_has_more, Tag, Error} ->
+            Error
+
+    after ?RESPONSE_TIMEOUT ->
+        {error, timeout}
     end.
+
+do_connect(Session, Pid, Keyspace) ->
+    erlcass_nif:cass_session_connect(Session, Pid, Keyspace).
+
+do_connect(Session, Pid) ->
+    erlcass_nif:cass_session_connect(Session, Pid).
 
 do_close(undefined, _Pid, _Timeout) ->
     ok;
@@ -393,22 +453,65 @@ session_create() ->
     case erlcass_nif:cass_session_new() of
         {ok, Session} ->
             Self = self(),
-            case do_connect(Session, Self) of
+            Keyspace = case erlcass_utils:get_env(keyspace) of
+                {ok, Space} -> Space;
+                _ -> ""
+            end,
+            KeyspaceCQL = case erlcass_utils:get_env(keyspace_cql) of
+                {ok, CQL} -> CQL;
+                _ -> ""
+            end,
+            Connect = case Keyspace of
+              ""       -> do_connect(Session, Self);
+              Keyspace -> do_connect(Session, Self, Keyspace)
+            end,
+            case Connect of
                 ok ->
-                    receive
-                        {session_connected, Self, Result} ->
-                            ?INFO_MSG("session ~p connection complete result: ~p", [Self, Result]),
-                            {ok, Session}
-
-                    after ?CONNECT_TIMEOUT ->
-                        ?ERROR_MSG("session ~p connection timeout", [Self]),
-                        {error, connect_session_timeout}
+                    case receive_session_connect(Keyspace, Self) of
+                        ok -> {ok, Session};
+                        {error, missing_keyspace} when KeyspaceCQL =/= "", Keyspace =/= "" ->
+                            ?INFO_MSG("Keyspace '~s' is missing, will create using: '~s'", [Keyspace, KeyspaceCQL]),
+                            ok = do_connect(Session, Self),
+                            case receive_session_connect("", Self) of
+                                ok ->
+                                    {ok, StmRef} = query_new_statement(KeyspaceCQL),
+                                    erlcass_nif:cass_session_execute(nil, Session, StmRef, Self, init_keyspace),
+                                    ?INFO_MSG("Creating Keyspace '~s'", [Keyspace]),
+                                    ok = receive_response(init_keyspace),
+                                    ?INFO_MSG("Keyspace '~s' Created", [Keyspace]),
+                                    ok = do_close(Session, Self, 5000),
+                                    ?INFO_MSG("Session Closed", []);
+                                Error -> Error
+                            end,
+                            ?INFO_MSG("Reconnecting with Keyspace", []),
+                            ok = do_connect(Session, Self, Keyspace),
+                            ?INFO_MSG("Waiting for coonection", []),
+                            case receive_session_connect(Keyspace, Self) of
+                                ok -> {ok, Session};
+                                Err -> Err
+                            end;
+                        Error -> Error
                     end;
                 Error ->
                     Error
             end;
         Error ->
             Error
+    end.
+
+receive_session_connect(Keyspace, Self) ->
+    MissingKeyspaceError = list_to_binary(lists:flatten(io_lib:format("Keyspace '~s' does not exist", [Keyspace]))),
+    receive
+        {session_connected, Self, {error, MissingKeyspaceError}} ->
+            {error, missing_keyspace};
+
+        {session_connected, Self, Result} ->
+            ?INFO_MSG("session ~p connection complete result: ~p", [Self, Result]),
+            ok
+
+    after ?CONNECT_TIMEOUT ->
+        ?ERROR_MSG("session ~p connection timeout", [Self]),
+        {error, connect_session_timeout}
     end.
 
 session_prepare_cached_statements(SessionRef) ->

--- a/src/erlcass_nif.erl
+++ b/src/erlcass_nif.erl
@@ -18,6 +18,7 @@
     cass_session_close/2,
     cass_session_prepare/4,
     cass_session_execute/5,
+    cass_session_execute_paged/5,
     cass_session_execute_batch/5,
     cass_session_get_metrics/1,
     cass_session_get_schema_metadata/1,
@@ -25,6 +26,7 @@
     cass_session_get_schema_metadata/3,
     cass_prepared_bind/1,
     cass_statement_new/1,
+    cass_statement_set_paging_size/2,
     cass_statement_bind_parameters/3,
     cass_uuid_gen_new/0,
     cass_uuid_gen_time/0,
@@ -91,6 +93,9 @@ cass_session_prepare(_SessionRef, _Pid, _Query, _Info) ->
 cass_session_execute(_Identifier, _SessionRef, _StatementRef, _FromPid, _Tag) ->
     ?NOT_LOADED.
 
+cass_session_execute_paged(_Identifier, _SessionRef, _StatementRef, _FromPid, _Tag) ->
+    ?NOT_LOADED.
+
 cass_session_execute_batch(_SessionRef, _BatchType, _StmList, _Options, _Pid) ->
     ?NOT_LOADED.
 
@@ -110,6 +115,9 @@ cass_prepared_bind(_PrepStatementRef) ->
     ?NOT_LOADED.
 
 cass_statement_new(_Query) ->
+    ?NOT_LOADED.
+
+cass_statement_set_paging_size(_StatementRef, _PageSize)->
     ?NOT_LOADED.
 
 cass_statement_bind_parameters(_StatementRef, _BindType, _Args)->


### PR DESCRIPTION
Also:
* Update to c++ driver 2.15.0
* Add flexibility to CASS_VALUE_TYPE_TEXT by supporting atoms
* Add flexibility to CASS_VALUE_TYPE_DOUBLE by implicilty converting int64 -> double
* Inrease erlang connect timeout to catch all callbacks (as c++ driver has 5s already)