### PR TITLE
upgrade datastax driver to 2.16.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{pre_hooks, [{"(linux|darwin)", compile, "make nif_compile CPP_DRIVER_REV=2.16.1"}]}.
+{pre_hooks, [{"(linux|darwin)", compile, "make nif_compile CPP_DRIVER_REV=2.16.2"}]}.
 {post_hooks, [{"(linux|darwin)", clean, "make nif_clean"}]}.
 
 {project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
Trying to build erlcass on Fedora 36 with OpenSSL 3.0 fails due to this issue: https://github.com/datastax/cpp-driver/pull/518

The fix was released in 2.16.2